### PR TITLE
Update LV-delay.md to include training step

### DIFF
--- a/docs/src/examples/LV-Flux.md
+++ b/docs/src/examples/LV-Flux.md
@@ -20,11 +20,12 @@ prob = ODEProblem(lotka_volterra,u0,(0.0,10.0),p)
 Then we define our loss function with `concrete_solve` for the adjoint method:
 
 ```julia
-function predict_rd(p)
+function predict_rd()
   Array(concrete_solve(prob,Tsit5(),u0,saveat=0.1,reltol=1e-4))
 end
-loss_rd() = sum(abs2,x-1 for x in predict_rd(p))
+loss_rd() = sum(abs2,x-1 for x in predict_rd())
 ```
+Note that the parameters `p` to be optimized are not passed as arguments to the `loss_rd` or `predict_rd` functions.  This is because `Flux.train!` below uses implicit globals.
 
 Now we setup the optimization. Here we choose the `ADAM` optimizer. To tell
 Flux what our parameters to optimize are, we use `Flux.params(p)`. To make the

--- a/docs/src/examples/LV-delay.md
+++ b/docs/src/examples/LV-delay.md
@@ -7,6 +7,7 @@ like:
 ```
 using DifferentialEquations, Flux, Optim, DiffEqFlux, DiffEqSensitivity
 
+
 # Define the same LV equation, but including a delay parameter
 function delay_lotka_volterra!(du, u, h, p, t)
   x, y = u
@@ -40,3 +41,23 @@ loss_dde(p) = sum(abs2, x-1 for x in predict_dde(p))
 
 Notice that we chose `sensealg = TrackerAdjoint()` to utilize the Tracker.jl
 reverse-mode to handle the delay differential equation.
+
+We define a callback to display the solution at the current parameters for each step of the training:
+
+```julia
+#using Plots
+cb = function (p,l...)
+  display(loss_dde(p))
+  #display(plot(solve(remake(prob_dde,p=p),MethodOfSteps(Tsit5()),saveat=0.1),ylim=(0,6)))
+  return false
+end
+
+cb(p,loss_dde(p))
+```
+
+We use `sciml_train` to optimize the parameters for our loss function:
+
+```julia
+result_dde = DiffEqFlux.sciml_train(loss_dde, p, ADAM(0.1),
+                                    cb = cb, maxiters = 100)
+```


### PR DESCRIPTION
The other examples all show either a `sciml_train` or a `Flux.train!` step at the end of the example. 
Adding a train step here for consistency